### PR TITLE
Implement ignore prefix regex

### DIFF
--- a/eventPage.js
+++ b/eventPage.js
@@ -1,4 +1,5 @@
 var patterns;
+var ignorePrefix;
 var disabled;
 
 function addListeners() {
@@ -18,9 +19,15 @@ function addListeners() {
 
 function loadPatterns() {
     chrome.storage.sync.get({
-        'patterns': []
+        'patterns': [],
+        'ignorePrefix': ''
     }, function(items) {
         patterns = items['patterns'];
+        if (items['ignorePrefix'] !== '') {
+            ignorePrefix = RegExp(items['ignorePrefix']);
+        } else {
+            ignorePrefix = null;
+        }
     });
 }
 
@@ -65,8 +72,8 @@ function rearrangeTabs() {
                 return tab.url.match(pattern);
             });
             patternTabs.sort(function(leftTab, rightTab) {
-                var left = leftTab.title;
-                var right = rightTab.title;
+                var left = leftTab.title.replace(ignorePrefix, '');
+                var right = rightTab.title.replace(ignorePrefix, '');
                 // We can't allow ties, so we sort first on title, then on ID,
                 // then, finally, on current index. ID should only be the same
                 // for special windows like apps and devtools.

--- a/popup.css
+++ b/popup.css
@@ -42,6 +42,8 @@ button {
 
 #help {
     display: none;
+    max-height: 150px;
+    overflow-y: scroll;
 }
 
 #help h2 {

--- a/popup.html
+++ b/popup.html
@@ -22,6 +22,10 @@
             in the same order as they are listed here.</p>
             <p>For example, "^https://github.com" would
             group all GitHub tabs together.</p>
+            <p>Set the Ignore Prefix to a regular expression that should be
+            ignored when sorting tabs. For example, for GitHub pull requests,
+            something like "\([0-9]+\)[ ]*" would keep tabs from being
+            reordered when there are unread comments.</p>
             <p><em>Remember to hit "Save" when you're finished.</em></p>
         </div>
         <div id="form">
@@ -30,8 +34,14 @@
                     <input id="disabled" type="checkbox">Disable
                 </label>
             </p>
-            <label for="patterns">URL Patterns</label>
-            <textarea id="patterns"></textarea>
+            <p>
+                <label for="patterns">URL Patterns</label>
+                <textarea id="patterns"></textarea>
+            </p>
+            <p>
+                <label for="ignore-prefix">Ignore Prefix</label>
+                <input id="ignore-prefix" type="text" />
+            </p>
             <button id="save" title="Save the current patterns.">Save</button>
             <button id="reload" title="Discard unsaved changes.">Reload</button>
             <button id="reset" title="Reset to default options.">Reset to Default</button>

--- a/popup.js
+++ b/popup.js
@@ -4,6 +4,7 @@ var defaultPatterns = [
 ];
 
 var currentPatternsContent;
+var currentIgnorePrefix;
 
 function loadPatterns() {
     var patternsBox = document.getElementById('patterns');
@@ -17,6 +18,16 @@ function loadPatterns() {
             patternsBox.value = patterns.join('\r\n');
         }
         currentPatternsContent = patternsBox.value;
+    });
+
+    // Ignore prefix
+    var ignorePrefixBox = document.getElementById('ignore-prefix');
+    chrome.storage.sync.get({
+        'ignorePrefix': ''
+    }, function(items) {
+        var ignorePrefix = items['ignorePrefix'];
+        ignorePrefixBox.value = ignorePrefix;
+        currentIgnorePrefix = ignorePrefixBox.value;
     });
 }
 
@@ -32,6 +43,15 @@ function savePatterns() {
     });
     currentPatternsContent = patternsBox.value;
     patternsBox.style.background = '';
+
+    // Ignore prefix
+    var ignorePrefixBox = document.getElementById('ignore-prefix');
+    var ignorePrefix = ignorePrefixBox.value;
+    chrome.storage.sync.set({
+        'ignorePrefix': ignorePrefix
+    });
+    currentIgnorePrefix = ignorePrefixBox.value;
+    ignorePrefixBox.style.background = '';
 }
 
 function resetStorage() {
@@ -101,6 +121,15 @@ document.addEventListener('DOMContentLoaded', function() {
     var patternsBox = document.getElementById('patterns');
     patternsBox.addEventListener('input', function(e) {
         if (e.target.value != currentPatternsContent) {
+            e.target.style.background = '#ffeeee';
+        } else {
+            e.target.style.background = '';
+        }
+    });
+
+    var ignorePrefixBox = document.getElementById('ignore-prefix');
+    ignorePrefixBox.addEventListener('input', function(e) {
+        if (e.target.value != currentIgnorePrefix) {
             e.target.style.background = '#ffeeee';
         } else {
             e.target.style.background = '';


### PR DESCRIPTION
Optionally ignore regex at the beginning of tab titles to avoid sorting anomalies when tabs change the title to denote activity.
