### PR TITLE
Delay for 1000ms on tab title changes

### DIFF
--- a/eventPage.js
+++ b/eventPage.js
@@ -2,8 +2,20 @@ var patterns;
 var ignorePrefix;
 var disabled;
 
+var isTimerSet = false;
+var debounceTime = 1000;
+
 function addListeners() {
-    chrome.tabs.onUpdated.addListener(rearrangeTabs);
+    chrome.tabs.onUpdated.addListener(function() {
+        if (isTimerSet) {
+            return;
+        }
+        isTimerSet = true;
+        setTimeout(function() {
+            rearrangeTabs();
+            isTimerSet = false;
+        }, debounceTime);
+    });
     chrome.tabs.onAttached.addListener(rearrangeTabs);
     chrome.tabs.onCreated.addListener(rearrangeTabs);
     chrome.storage.onChanged.addListener(function(changes) {


### PR DESCRIPTION
This should resolve #8. We only update based on tab title changes once every second so that rapid title changes don't cause the tabs to fly around. I'm wondering if the delay should actually be a little longer.